### PR TITLE
Corrected searching of homedirs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ chmod a+w $NAME_VAR_AUTO_ROTATE $NAME_VAR_AUTO_ROTATE_ONLY_TABLET
 # so let's take the first available one
 
 found=false
-for home in "${HOME_DIRS[@]}"; do
+for home in ${HOME_DIRS[@]}; do
   if [ -d "$home" ]; then
     if [ -f "$home/.Xauthority" ]; then
       USER_NAME=$(basename "$home")


### PR DESCRIPTION
In the original version, there is no iteration over all users, all subdirectories /home are simply contained in the "home" variable